### PR TITLE
SensorLogger for mobile

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="jp.co.megachips.sensorlogger" >
 
+    <uses-feature android:name="android.hardware.type.watch" />
     <uses-permission android:name="android.permission.BODY_SENSORS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -10,16 +11,18 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@android:style/Theme.DeviceDefault" >
         <activity
-            android:name=".SensorLogger"
-            android:label="@string/app_name" >
+            android:name=".MainActivity"
+            android:label="@string/app_name"
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service android:name=".SensorLogger"/>
     </application>
 
 </manifest>

--- a/mobile/src/main/java/jp/co/megachips/sensorlogger/MainActivity.java
+++ b/mobile/src/main/java/jp/co/megachips/sensorlogger/MainActivity.java
@@ -1,0 +1,82 @@
+package jp.co.megachips.sensorlogger;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+
+public class MainActivity extends Activity{
+
+    private final String TAG = "SensorLogger";
+
+    private int mAcclType = 0;
+    private int mMagnType = 0;
+    private int mGyroType = 0;
+    private int mPresType = 0;
+    private TextView mTextView = null;
+    MyBroadcastReceiver mReceiver = new MyBroadcastReceiver();
+
+    public String getVersionName(){
+        PackageInfo packageInfo = null;
+        try{
+            packageInfo = getPackageManager().getPackageInfo(getPackageName(), PackageManager.GET_META_DATA);
+        }catch (PackageManager.NameNotFoundException e){
+        }
+        return packageInfo.versionName;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sensor_logger);
+
+        mTextView = (TextView)findViewById(R.id.text_view);
+        String str = "";
+        str += "SensorLogger version: " + getVersionName() + "\n";
+        str += "Accl: "; str += (mAcclType == 0) ? "false\n" : "true\n";
+        str += "Magn: "; str += (mMagnType == 0) ? "false\n" : "true\n";
+        str += "Gyro: "; str += (mGyroType == 0) ? "false\n" : "true\n";
+        str += "Pres: "; str += (mPresType == 0) ? "false\n" : "true\n";
+        mTextView.setText(str);
+
+        Button button = (Button)findViewById(R.id.button);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(MainActivity.this, SensorLogger.class);
+                stopService(intent);
+                finish();
+            }
+        });
+
+        Intent intent = new Intent(this, SensorLogger.class);
+        startService(intent);
+
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(TAG);
+        registerReceiver(mReceiver, intentFilter);
+    }
+
+    @Override
+    public void onDestroy(){
+        unregisterReceiver(mReceiver);
+        super.onDestroy();
+    }
+
+    public class MyBroadcastReceiver extends BroadcastReceiver{
+        @Override
+        public void onReceive(Context context, Intent intent){
+            String str = "SensorLogger version: " + getVersionName() + "\n";
+            str += intent.getExtras().getString("message");
+            mTextView.setText(str);
+        }
+    }
+}

--- a/mobile/src/main/java/jp/co/megachips/sensorlogger/SensorLogger.java
+++ b/mobile/src/main/java/jp/co/megachips/sensorlogger/SensorLogger.java
@@ -1,38 +1,467 @@
+
 package jp.co.megachips.sensorlogger;
 
-import android.support.v7.app.ActionBarActivity;
-import android.os.Bundle;
-import android.view.Menu;
-import android.view.MenuItem;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Environment;
+import android.os.IBinder;
+import android.os.PowerManager;
+import android.support.v4.app.NotificationCompat;
+import android.util.Log;
+import android.hardware.Sensor;
+import android.hardware.SensorManager;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorEvent;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.util.Date;
+import java.text.SimpleDateFormat;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 
-public class SensorLogger extends ActionBarActivity {
+public class SensorLogger extends Service implements Runnable, SensorEventListener {
+    private final String TAG = "SensorLogger";
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_sensor_logger);
+    private final int SamplingPeriodUs = 10 * 1000;
+    private final int MaxReportLatencyUs = 0 * 1000 * 1000;
+    private int mOverFlow = 0;
+
+    private final Thread mThread = new Thread(this);
+    private PowerManager mPowerManager;
+    private PowerManager.WakeLock mWL;
+    private SensorManager mSensorManager;
+    private BufferedWriter mBW = null;
+
+    private static final String[] mSensors = {"Gyro", "Accl", "Magn", "Temp", "Pres"};
+    private Map<String, TargetSensorType> mSensorType = new HashMap<>();
+    private Map<String, SensorEventQueue> mSensorEventQueue = new HashMap<>();
+
+    public String StringFormat(String sensor, float[] values, boolean flag){
+        String str = "";
+        if(sensor != null){
+            switch (sensor){
+                case "Accl":
+                    str = (flag) ? String.format(" %e %e %e", values[0]/SensorManager.STANDARD_GRAVITY, values[1]/SensorManager.STANDARD_GRAVITY, values[2]/SensorManager.STANDARD_GRAVITY) : " na na na";
+                    break;
+                case "Magn":
+                    str = (flag) ? String.format(" %e %e %e", values[0]/100, values[1]/100, values[2]/100) : " na na na";
+                    break;
+                case "Gyro":
+                    str = (flag) ? String.format(" %e %e %e", values[0], values[1], values[2]) : " na na na";
+                    break;
+                case "Pres":
+                    str = (flag) ? String.format(" na %e", values[0]) : " na na";
+                    break;
+                case "Temp":
+                    str = " na na na";
+                    break;
+                default:
+                    break;
+            }
+        }
+        return str;
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_sensor_logger, menu);
-        return true;
+    private long mCounter = 0;
+
+    private String mOutputFileName;
+    private File mOutputDir;
+
+    private int mDivCount = 1;
+    private long mFlushCounter = 0;
+    private static final int FLUSH_COUNT_MAX = 60000;
+    private static final int QUEUE_DEPTH = 100;
+
+    private Intent mBroadcastIntent = new Intent();
+
+    class TargetSensorType {
+        public int type;
+        public boolean wakeUp;
+        public boolean uncalibrated;
+        TargetSensorType(int type, boolean wakeUp, boolean uncalibrated) { this.type = type; this.wakeUp = wakeUp; this.uncalibrated = uncalibrated; }
     }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
-        int id = item.getItemId();
+    private final Map<String, TargetSensorType[]> mSensorPriorList = new HashMap<String, TargetSensorType[]>(){
+        {put("Accl", new TargetSensorType[]{
+                        new TargetSensorType(Sensor.TYPE_ACCELEROMETER, true, false),
+                        new TargetSensorType(Sensor.TYPE_ACCELEROMETER, false, false),
+                }
+        );}
+        {put("Magn", new TargetSensorType[]{
+                        new TargetSensorType(Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED, true, true),
+                        new TargetSensorType(Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED, false, true),
+                        new TargetSensorType(Sensor.TYPE_MAGNETIC_FIELD, true, false),
+                        new TargetSensorType(Sensor.TYPE_MAGNETIC_FIELD, false, false),
+                }
+        );}
+        {put("Gyro", new TargetSensorType[]{
+                        new TargetSensorType(Sensor.TYPE_GYROSCOPE_UNCALIBRATED, true, true),
+                        new TargetSensorType(Sensor.TYPE_GYROSCOPE_UNCALIBRATED, false, true),
+                        new TargetSensorType(Sensor.TYPE_GYROSCOPE, true, false),
+                        new TargetSensorType(Sensor.TYPE_GYROSCOPE, false, false),
+                }
+        );}
+        {put("Temp", new TargetSensorType[]{
+                        new TargetSensorType(Sensor.TYPE_AMBIENT_TEMPERATURE, true, false),
+                        new TargetSensorType(Sensor.TYPE_AMBIENT_TEMPERATURE, false, false),
+                }
+        );}
+        {put("Pres", new TargetSensorType[]{
+                        new TargetSensorType(Sensor.TYPE_PRESSURE, true, false),
+                        new TargetSensorType(Sensor.TYPE_PRESSURE, false, false),
+                }
+        );}
+    };
 
-        //noinspection SimplifiableIfStatement
-        if (id == R.id.action_settings) {
-            return true;
+    private TargetSensorType SensorRegsit(TargetSensorType[] list, int max_report_latency_us) {
+        TargetSensorType ret = new TargetSensorType(0, false, false);
+        for(TargetSensorType type: list){
+            Sensor sensor;
+            if(Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                sensor = mSensorManager.getDefaultSensor(type.type);
+            }
+            else{
+                sensor = mSensorManager.getDefaultSensor(type.type, type.wakeUp);
+            }
+            if(sensor != null) {
+                mSensorManager.registerListener(this, sensor, SamplingPeriodUs, max_report_latency_us);
+                ret.type = type.type;
+                ret.uncalibrated = type.uncalibrated;
+                return ret;
+            }
+        }
+        return ret;
+    }
+
+    public class SensorData {
+        public long timestamp = 0;
+        public final float[] values = new float[3];
+    }
+    class SensorEventQueue {
+        private SensorData[] mRingData = null;
+        private int mDepth;
+        private int mNum;
+        private int mTop, mBot;
+        SensorEventQueue(int depth) {
+            mDepth = depth;
+            mRingData = new SensorData[depth];
+            for(int i = 0; i < mDepth; i++){
+                mRingData[i] = new SensorData();
+            }
+        }
+        synchronized boolean push(SensorData data) {
+            boolean ret = true;
+            if(mNum == mDepth){
+                ret = false;
+            }
+            else if(data != null){
+                mRingData[mBot].timestamp = data.timestamp;
+                mRingData[mBot].values[0] = data.values[0];
+                mRingData[mBot].values[1] = data.values[1];
+                mRingData[mBot].values[2] = data.values[2];
+                mNum++; mBot++;
+                if(mDepth <= mBot){
+                    mBot = 0;
+                }
+            }
+            return ret;
+        }
+        synchronized int size() { return mNum; }
+        synchronized boolean peek(SensorData data, int dist) {
+            boolean ret = true;
+            if(mNum <= dist){
+                if(0 == dist) {
+                    mNum = 0;
+                }
+                ret = false;
+            }
+            else if(data != null) {
+                if (mTop + dist < mDepth) {
+                    data.timestamp = mRingData[mTop + dist].timestamp;
+                    data.values[0] = mRingData[mTop + dist].values[0];
+                    data.values[1] = mRingData[mTop + dist].values[1];
+                    data.values[2] = mRingData[mTop + dist].values[2];
+                }else{
+                    data.timestamp = mRingData[mTop + dist - mDepth].timestamp;
+                    data.values[0] = mRingData[mTop + dist - mDepth].values[0];
+                    data.values[1] = mRingData[mTop + dist - mDepth].values[1];
+                    data.values[2] = mRingData[mTop + dist - mDepth].values[2];
+                }
+            }
+            return ret;
+        }
+        synchronized boolean peek(SensorData data){
+            return peek(data, 0);
         }
 
-        return super.onOptionsItemSelected(item);
+        synchronized boolean pop(SensorData data) {
+            boolean ret = peek(data);
+            if(ret){
+                mNum--; mTop++;
+                if(mDepth <= mTop){
+                    mTop = 0;
+                }
+            }
+            return ret;
+        }
+    }
+    SensorData mQueueR = null;
+    SensorData mQueueW = null;
+
+    public void changeWriteFile(){
+        if(null != mBW){
+            try {
+                mBW.close();
+                mBW = null;
+            }catch (IOException e){
+            }
+        }
+        if (isExternalStorageWritable()) {
+            String serialNum = String.format("_%03d", mDivCount);
+            File file = new File(mOutputDir, mOutputFileName + serialNum + ".txt");
+            try {
+                mBW = new BufferedWriter(new FileWriter(file));
+                mDivCount++;
+            }
+            catch (IOException e) {
+            }
+        }
+    }
+
+    @Override
+    public void onCreate(){
+        mPowerManager = (PowerManager)getSystemService(POWER_SERVICE);
+        mWL = mPowerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SensorLogger");
+        mWL.acquire();
+        mSensorManager = (SensorManager)getSystemService(SENSOR_SERVICE);
+        for(Sensor p : mSensorManager.getSensorList(Sensor.TYPE_ALL)) {
+            Log.i(TAG, p.toString());
+        }
+        if(isExternalStorageWritable()) {
+            SimpleDateFormat form = new SimpleDateFormat("yyyyMMdd_HHmmss");
+            mOutputFileName = form.format(new Date());
+            File root = android.os.Environment.getExternalStorageDirectory();
+            mOutputDir = new File(root.getAbsolutePath() + "/SensorLogger");
+            mOutputDir.mkdirs();
+            changeWriteFile();
+        }
+        if(mSensorManager != null) {
+            mThread.setPriority(Thread.MAX_PRIORITY);
+            mThread.start();
+            // Regist sensors
+            for (String sensor : mSensors){
+                mSensorType.put(sensor, SensorRegsit(mSensorPriorList.get(sensor), MaxReportLatencyUs));
+            }
+            // create Queue
+            for (String sensor : mSensors){
+                if(mSensorType.get(sensor).type != 0) {
+                    mSensorEventQueue.put(sensor, new SensorEventQueue(QUEUE_DEPTH));
+                }
+            }
+            mQueueR = new SensorData();
+            mQueueW = new SensorData();
+        }
+        showNotification();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        String str = "";
+        for(String sensor : mSensors){
+            str += sensor;
+            str += (mSensorType.get(sensor).uncalibrated) ? " uncalibrated: " : ": ";
+            str += (mSensorType.get(sensor).type == 0) ? "false\n" : "true\n";
+        }
+
+        mBroadcastIntent.putExtra("message", str);
+        mBroadcastIntent.setAction(TAG);
+        getBaseContext().sendBroadcast(mBroadcastIntent);
+
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            synchronized (mThread) {
+                if(mSensorManager != null) {
+                    mSensorManager.unregisterListener(this);
+                    mWL.release();
+                    mWL = null;
+                    mSensorManager = null;
+                }
+                mThread.notify();
+            }
+            mThread.join();
+            mQueueW.timestamp = mCounter + SamplingPeriodUs * 1000 ;
+            for(int i=0; i<3; i++) {
+                mQueueW.values[i] = 0;
+            }
+            for(String sensor : mSensors){
+                if(mSensorEventQueue.containsKey(sensor)) {
+                    mSensorEventQueue.get(sensor).push(mQueueW);
+                }
+            }
+            while(FlushData()){
+            }
+            mSensorEventQueue.clear();
+            mSensorType.clear();
+            mQueueR = null;
+            mQueueW = null;
+        }
+        catch (Exception e) {
+        }
+        if(mBW != null) {
+            try {
+                mBW.close();
+                mBW = null;
+            }
+            catch (IOException e) {
+            }
+        }
+        super.onDestroy();
+    }
+
+    private boolean isExternalStorageWritable() {
+        String state = Environment.getExternalStorageState();
+        return Environment.MEDIA_MOUNTED.equals(state);
+    }
+
+    private boolean FlushData() {
+        boolean enable = true;
+        String str ="";
+        for (final String sensor: mSensors) {
+            if ((mSensorType.get(sensor).type != 0) && (mSensorEventQueue.get(sensor).size() == 0)) {
+                enable = false;
+            }
+        }
+        if(enable) {
+            if (mCounter == 0) {
+                for(final String sensor: mSensors){
+                    if(mSensorType.get(sensor).type != 0){
+                        mSensorEventQueue.get(sensor).peek(mQueueR);
+                        if (mCounter < mQueueR.timestamp) {
+                            mCounter = mQueueR.timestamp;
+                        }
+                    }
+                }
+            }
+            str += String.format("0x%x 0x%x", System.currentTimeMillis(), mCounter);
+            for (String sensor: mSensors){
+                if (mSensorType.get(sensor).type != 0){
+                    while (mSensorEventQueue.get(sensor).peek(mQueueR, 1)){
+                        if (mCounter < mQueueR.timestamp){
+                            mSensorEventQueue.get(sensor).peek(mQueueR);
+                            str += StringFormat(sensor, mQueueR.values, true);
+                            break;
+                        }
+                        else{
+                            mSensorEventQueue.get(sensor).pop(null);
+                        }
+                    }
+                    if (mSensorEventQueue.get(sensor).size() <= 1){
+                        enable = false;
+                    }
+                }
+                else {
+                    str += StringFormat(sensor, null, false);
+                }
+            }
+            if (enable) {
+                str += String.format(" %f\n", (float)SamplingPeriodUs/1000000.0);
+                try {
+                    mBW.write(str);
+                }
+                catch (IOException e){
+                }
+                mCounter += SamplingPeriodUs * 1000;
+            }
+        }
+        return enable;
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (true) {
+                synchronized (mThread) {
+                    if(mSensorManager == null){
+                        break;
+                    }
+                    mThread.wait();
+                }
+                while (true) {
+                    if(!FlushData()){
+                        break;
+                    }else{
+                        mFlushCounter++;
+                        if(mFlushCounter > FLUSH_COUNT_MAX){
+                            mFlushCounter=0;
+                            changeWriteFile();
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception e) {
+        }
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        boolean push_ret = true;
+        int type = event.sensor.getType();
+//        mQueueW.timestamp = event.timestamp;
+        mQueueW.timestamp = System.currentTimeMillis() * 1000 * 1000; /// unit of nano-sec
+        mQueueW.values[0] = event.values[0];
+        mQueueW.values[1] = event.values[1];
+        mQueueW.values[2] = event.values[2];
+        for(String sensor : mSensors){
+            if(type == mSensorType.get(sensor).type){
+                push_ret = mSensorEventQueue.get(sensor).push(mQueueW);
+                break;
+            }
+        }
+        if(mBW != null) {
+            synchronized (mThread) {
+                mThread.notify();
+            }
+        }
+        if(!push_ret){
+            mOverFlow++;
+            if (mOverFlow <= 1000 || mOverFlow % 100 == 0) {
+                mBroadcastIntent.putExtra("message", String.format("OverFlow!!!: %d", mOverFlow));
+                mBroadcastIntent.setAction(TAG);
+                getBaseContext().sendBroadcast(mBroadcastIntent);
+            }
+        }
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
+    }
+
+    private void showNotification(){
+        Intent intent = new Intent(this, MainActivity.class);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext());
+        builder.setContentIntent(pendingIntent);
+        builder.setContentTitle("SensorLogger is running.");
+        builder.setContentText("Touch to open the app.");
+        builder.setSmallIcon(R.mipmap.ic_launcher);
+        builder.extend(new NotificationCompat.WearableExtender().setContentAction(0)
+                .addAction(new NotificationCompat.Action.Builder(R.mipmap.ic_launcher, "", pendingIntent).build()));
+        startForeground(1, builder.build());
+    }
+
+    @Override
+    public IBinder onBind(Intent intent){
+        throw new UnsupportedOperationException("Not yet supported");
     }
 }

--- a/mobile/src/main/res/layout/activity_sensor_logger.xml
+++ b/mobile/src/main/res/layout/activity_sensor_logger.xml
@@ -3,9 +3,19 @@
     android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin" tools:context=".SensorLogger">
+    android:paddingBottom="@dimen/activity_vertical_margin" tools:context=".MainActivity">
 
-    <TextView android:text="@string/hello_world" android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+    <TextView android:text="Sensor Logger"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/text_view"/>
+
+    <Button android:text="exit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/button"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentEnd="true" />
 
 </RelativeLayout>
+


### PR DESCRIPTION
wearのセンサーロガーをmobile用に移しました。
wearからの変更として、onSensorChangedでイベントを受け取った際、event.timestampの値をSystem.currentTimeMillsで上書きするようにしています。

Geak watchで以下を動作確認しました：
* 加速度、ジャイロともに不自然なデータの飛びは無く、正常に取得できていることを確認
* アプリを終了してもサービスとして裏でデータ取得できていることを確認
* ファイル分割、書き込みできていることを確認

注意点としては、アプリを終了しても、アプリ画面でexitボタンを押さない限りデータ取得し続けます（I95対応のため）